### PR TITLE
Fix for dismissing Unity interstitial ads

### DIFF
--- a/lib/src/easy_unity/easy_unity_ad.dart
+++ b/lib/src/easy_unity/easy_unity_ad.dart
@@ -50,6 +50,9 @@ class EasyUnityAd extends EasyUnityAdBase {
         onAdShowed?.call(adNetwork, adUnitType, null);
       } else if (state == UnityAdState.skipped) {
         onAdDismissed?.call(adNetwork, adUnitType, null);
+      } else if (adUnitType == AdUnitType.interstitial &&
+          state == UnityAdState.complete) {
+        onAdDismissed?.call(adNetwork, adUnitType, null);
       } else if (adUnitType == AdUnitType.rewarded &&
           state == UnityAdState.complete) {
         onEarnedReward?.call(adNetwork, adUnitType, null, null);


### PR DESCRIPTION
Fix for Dismiss-event not being fired when dismissing Unity ads (ony skipping an Unity ad and then dismissing the ad triggered the Dismiss-event before this fix)